### PR TITLE
fix: fixed error thrown when running using a scheduled workflow

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12339,6 +12339,7 @@ const core = __importStar(__webpack_require__(470));
 const exec = __importStar(__webpack_require__(986));
 const Github = __importStar(__webpack_require__(469));
 const ghClient = process.env.GITHUB_TOKEN && new Github.GitHub(process.env.GITHUB_TOKEN);
+const { GITHUB_REPOSITORY = '' } = process.env;
 let execLogs = '';
 const execOptions = {
     listeners: {
@@ -12364,9 +12365,7 @@ const rebase = async (args) => {
 const run = async () => {
     const branchtomerge = core.getInput('branchtomerge');
     const branch = core.getInput('branch');
-    const context = await Github.context;
-    const repo = context.payload.repository.full_name.split('/');
-    const [owner] = repo;
+    const [owner] = GITHUB_REPOSITORY.split('/');
     const client = ghClient;
     if (!client)
         throw 'Failed to load Github client from token.';

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,8 @@ import * as Github from '@actions/github';
 
 const ghClient = process.env.GITHUB_TOKEN && new Github.GitHub(process.env.GITHUB_TOKEN);
 
+const { GITHUB_REPOSITORY = '' } = process.env;
+
 let execLogs = '';
 
 const execOptions = {
@@ -40,9 +42,7 @@ const rebase = async (args: RebaseArgs): Promise<void> => {
 const run = async (): Promise<void> => {
   const branchtomerge = core.getInput('branchtomerge');
   const branch = core.getInput('branch');
-  const context = await Github.context;
-  const repo = context.payload.repository!.full_name!.split('/');
-  const [owner] = repo!;
+  const [owner] = GITHUB_REPOSITORY.split('/');
 
   const client = ghClient;
 


### PR DESCRIPTION
When running workflow on a cron schedule, getting the owner name of the repository would throw the following error:
```
(node:2691) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'full_name' of undefined
    at run (/home/runner/work/_actions/MaximeHeckel/github-action-merge-fast-forward/v1.1.0/dist/index.js:12368:45)
(node:2691) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2691) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This PR fixes that issue by using the `GITHUB_REPOSITORY` env variable instead.

Note: I had some problems with getting the dependencies to lock correctly, e.g. `yarn --ci` did not produce the same result as the committed node_modules, therefore I decided to use the commited node_modules to generate the dist bundle.