### PR TITLE
Upgrade runtime Node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Branch that will be updated'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'git-merge'


### PR DESCRIPTION
Github Actions infrastructure requires all actions to run minimum on Node 16